### PR TITLE
vector query by document_id usecase

### DIFF
--- a/src/content/docs/api/rest-api/overview.md
+++ b/src/content/docs/api/rest-api/overview.md
@@ -13,7 +13,7 @@ This document provides an overview of the Cosdata vector database REST API, whic
 
 The base URL for all API endpoints is: `https://host:port/vectordb`
 
-For detailed authentication information, see [Authentication](rest-api/authentication.md).
+For detailed authentication information, see [Authentication](/api/rest-api/authentication/).
 
 ## API Endpoints
 
@@ -23,25 +23,25 @@ The API is organized into the following sections:
 
 Collection management endpoints for creating, listing, and managing vector collections.
 
-[View Collections API Documentation](rest-api/collections.md)
+[View Collections API Documentation](/api/rest-api/collections/)
 
 ### Transactions
 
 Transaction management endpoints for performing atomic operations on vectors.
 
-[View Transactions API Documentation](rest-api/transactions.md)
+[View Transactions API Documentation](/api/rest-api/transactions/)
 
 ### Search
 
 Search endpoints for performing vector similarity search and text search.
 
-[View Search API Documentation](rest-api/search.md)
+[View Search API Documentation](/api/rest-api/search/)
 
 ### Index Management
 
 Index management endpoints for optimizing search performance.
 
-[View Index Management API Documentation](rest-api/indexes.md)
+[View Index Management API Documentation](/api/rest-api/indexes/)
 
 ## Best Practices
 

--- a/src/content/docs/api/rest-api/vectors.md
+++ b/src/content/docs/api/rest-api/vectors.md
@@ -5,7 +5,7 @@ description: Endpoints for querying and retrieving vectors in the Cosdata vector
 ---
 
 
-> **Note:** To add vectors to the database, use the [Transactions API](./transactions.md). The endpoints below are for querying and retrieving vectors only.
+> **Note:** To add vectors to the database, use the [Transactions API](/api/rest-api/transactions/). The endpoints below are for querying and retrieving vectors only.
 
 ---
 

--- a/src/content/docs/api/rest-api/vectors.md
+++ b/src/content/docs/api/rest-api/vectors.md
@@ -2,12 +2,17 @@
 title: Vector Operations API
 description: Endpoints for querying and retrieving vectors in the Cosdata vector database
 ---
+---
+
 
 > **Note:** To add vectors to the database, use the [Transactions API](./transactions.md). The endpoints below are for querying and retrieving vectors only.
 
+---
+
+
 ## Query Vectors by DocumentId
 
-Retrieves all vectors associated with a specific document ID in a collection.
+Retrieves all vectors associated with a specific document ID in a collection. This is especially useful when you want to fetch all the vectorized chunks of a document (such as a PDF split into pages or sections) for downstream processing, analysis, or display.
 
 **Endpoint:** `GET /vectordb/collections/{collection_id}/vectors?document_id={document_id}`
 
@@ -25,24 +30,24 @@ Retrieves all vectors associated with a specific document ID in a collection.
 
 **Response:**
 
-  ```json
-  [
-    {
-      "id": "vector_id_1",
-      "document_id": "doc123",
-      "dense_values": [0.1, 0.2, 0.3, ...],
-      "sparse_values": null,
-      "text": "Optional text content"
-    },
-    {
-      "id": "vector_id_2",
-      "document_id": "doc123",
-      "dense_values": [0.4, 0.5, 0.6, ...],
-      "sparse_values": null,
-      "text": "Optional text content"
-    }
-  ]
-  ```
+```json
+[
+  {
+    "id": "vector_id_1",
+    "document_id": "doc123",
+    "dense_values": [0.1, 0.2, 0.3, ...],
+    "sparse_values": null,
+    "text": "Optional text content"
+  },
+  {
+    "id": "vector_id_2",
+    "document_id": "doc123",
+    "dense_values": [0.4, 0.5, 0.6, ...],
+    "sparse_values": null,
+    "text": "Optional text content"
+  }
+]
+```
 
 **Status Codes:**
 
@@ -52,7 +57,34 @@ Retrieves all vectors associated with a specific document ID in a collection.
 | 400  | Bad Request. Collection not found or other validation error. |
 | 500  | Server Error. Internal database or server error.           |
 
----
+
+### Use Case: Fetching All Vectors for a Document (Chunked PDF Example)
+
+When working with documents such as PDFs, it's common to split ("chunk") the document into smaller sections such as pages, paragraphs, or sentences. Each chunk is then processed through an embedding model to generate a vector representation, and these vectors are indexed in the Cosdata vector database. All vectors generated from the same document are associated with a shared `document_id`.
+
+**Why is this useful?**
+
+- **Semantic Search:** Enables searching or analyzing specific parts of a document at a fine-grained level.
+- **Reconstruction:** Allows you to retrieve all vectorized chunks for a document, which can be used to reconstruct or display the original content in context.
+- **Debugging & Auditing:** Useful for inspecting how a document was split and embedded, or for troubleshooting embedding/modeling issues.
+
+**Example Scenario:**
+
+Suppose you have a PDF with 3 pages. Each page is chunked and embedded, resulting in multiple vectors (one per chunk). All these vectors are stored with the same `document_id` (e.g., `doc123`). If you want to fetch all the vectors for this document (to analyze, re-embed, or display them), you can use the API below.
+
+**Example using curl:**
+
+```bash
+curl -X GET \
+  "https://localhost:8443/vectordb/collections/my_collection/vectors?document_id=doc123" \
+  -H "Authorization: Bearer <YOUR_API_KEY>"
+```
+
+Replace `my_collection` with your collection ID, `doc123` with your document ID, and `<YOUR_API_KEY>` with your actual API key.
+
+Retrieves all vectors associated with a specific document ID in a collection. This is especially useful when you want to fetch all the vectorized chunks of a document (such as a PDF split into pages or sections) for downstream processing, analysis, or display.
+
+
 
 ## Get Vector by ID
 
@@ -87,8 +119,6 @@ Retrieves a specific vector by its ID.
 | 400  | Bad Request. Collection not found or other validation error. |
 | 404  | Not Found. Vector with the specified ID not found.         |
 | 500  | Server Error. Internal database or server error.           |
-
----
 
 ## Check Vector Existence
 


### PR DESCRIPTION
This pull request updates the documentation for the Cosdata vector database REST API to improve clarity and consistency. The key changes include updating internal links to use absolute paths, enhancing descriptions for vector operations, and adding practical examples and use cases for better understanding.

### Documentation Improvements:

* **Updated Links to Absolute Paths**:
  - Changed internal links in `src/content/docs/api/rest-api/overview.md` to use absolute paths (e.g., `/api/rest-api/authentication/`), ensuring consistency and preventing broken links. [[1]](diffhunk://#diff-1c8c7841b49c3772f9743f94bf35c063301f134b808f2d823fec33a170f2daf6L16-R16) [[2]](diffhunk://#diff-1c8c7841b49c3772f9743f94bf35c063301f134b808f2d823fec33a170f2daf6L26-R44)

* **Enhanced Vector Operations API**:
  - Added a detailed use case for fetching all vectors associated with a document ID, including practical scenarios such as semantic search, reconstruction, and debugging. This includes an example using `curl` for clarity.
  - Improved the description of the "Query Vectors by DocumentId" endpoint to highlight its utility in downstream processing, analysis, or display of vectorized document chunks.
